### PR TITLE
Include customer payment

### DIFF
--- a/app/controllers/payment_methods_controller.rb
+++ b/app/controllers/payment_methods_controller.rb
@@ -21,12 +21,14 @@ class PaymentMethodsController
     end
 
     def add_payment_method
+        @active_customer = active_customer[0]
+        puts @active_customer
         puts "Name of Payment Method?"
         @payment_type = gets.chomp
         puts "Account Number?"
         @account_number = gets.chomp
-        added_method = @payment_method.add_payment_method(@payment_type, @account_number)
-        print "Added '#{added_method[0][1]}' Account#: #{added_method[0][2]}"
+        added_method = @payment_method.add_payment_method(@active_customer, @payment_type, @account_number)
+        print "Added '#{added_method[0][2]}' Account#: #{added_method[0][3]} for Customer ID: #{added_method[0][1]}"
     end
 
 end

--- a/app/models/order_line.rb
+++ b/app/models/order_line.rb
@@ -5,7 +5,7 @@ class OrderLineModel
   # attr_accessor
 
   def initialize
-    @db = SQLite3::Database.open("/Users/hiattcollins/workspace/bangazon/bangazon-terminal-interface/bangazon_cli.db")
+    @db = SQLite3::Database.open(ENV["BANGAZONTI"])
   end
 
   def get_all_order_lines

--- a/app/models/payment_method.rb
+++ b/app/models/payment_method.rb
@@ -12,8 +12,8 @@ class PaymentMethod
         return pay_array
     end
 
-    def add_payment_method(payment_type, account_number)
-        @db.execute "INSERT INTO Payment_methods VALUES (null, '#{payment_type}', #{account_number});"
+    def add_payment_method(customer_id, payment_type, account_number)
+        @db.execute "INSERT INTO Payment_methods VALUES (null, #{customer_id}, '#{payment_type}', #{account_number});"
         new_id = @db.last_insert_row_id
         added_pay_method = @db.execute "SELECT * FROM Payment_methods WHERE pay_method_id = #{new_id};"
         @db.close

--- a/spec/models/order_line_spec.rb
+++ b/spec/models/order_line_spec.rb
@@ -20,7 +20,7 @@ describe OrderLineModel do
     context "before new order line is added to db" do
       it "checks to make sure the order line does not already exist" do
         order_lines = OrderLineModel.new
-        @db = SQLite3::Database.open("../../bangazon_cli.db")
+        @db = SQLite3::Database.open(ENV["BANGAZONTI"])
         check_for_order = @db.execute("SELECT * FROM Order_details WHERE order_detail_id = 23")
         p check_for_order
           expect(check_for_order).to eql([])
@@ -46,7 +46,7 @@ describe OrderLineModel do
       it "successfully deletes the order line corresponding to the id submitted" do
         order_lines = OrderLineModel.new
         order_lines.delete_order_line(23)
-        @db = SQLite3::Database.open("../../bangazon_cli.db")
+        @db = SQLite3::Database.open(ENV["BANGAZONTI"])
         check_for_line = @db.execute("SELECT * FROM Order_details WHERE order_detail_id = 23")
         p check_for_line
           expect(check_for_line).to eql([])

--- a/spec/models/payment_method_spec.rb
+++ b/spec/models/payment_method_spec.rb
@@ -30,12 +30,13 @@ describe "add_payment_method" do
   context "when called" do
     it "adds a product and verifies the field types and values" do
       setup
-      pay_method = @pm.add_payment_method("Criminal Bank", 1000000000000000)
+      pay_method = @pm.add_payment_method(1, "Criminal Bank", 1000000000000000)
 
       expect(pay_method).to be_an(Array)
       expect(pay_method.flatten[0]).to be_an(Integer)
-      expect(pay_method.flatten[1]).to eq("Criminal Bank")
-      expect(pay_method.flatten[2]).to eq(1000000000000000)
+      expect(pay_method.flatten[1]).to eq(1)
+      expect(pay_method.flatten[2]).to eq("Criminal Bank")
+      expect(pay_method.flatten[3]).to eq(1000000000000000)
       #sets test_id_1 to delete this example record at the end of the tests
       test_id_1 = pay_method.flatten[0]
     end
@@ -60,18 +61,3 @@ describe "delete test entry" do
         end
     end
 end
-
-
-
-
-
-
-
-
-
-#     it "should remove the example entries" do
-
-#     end
-# end
-
-# end


### PR DESCRIPTION
## Pull Request

#### Description

The description that you provide should be comprehensive enough to...

1. I added a customer_id field to the payment_method table in the SQL file
1. Changed the tests to reflect the new field.
1. Added the "Add payment method" functionality to the MAIN MENU.
1. Changed the db path to the ENV variable in the order_line_spec in order to make the DB universally available.

#### Steps to Test

1. run `bundle exec rspec --format doc`
1. run the app `ruby app/main.rb`
1. follow the UI instuctions to Add a Payment Method
1. confirm in the database that the proper information was added

#### Link to Feature Ticket

https://github.com/c-cannons/bangazon-terminal-interface/issues/3