### PR TITLE
remove products method now checks active orders for product to be rem…

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,4 +1,5 @@
 require_relative "../models/product"
+require_relative "../models/order_line"
 
 class ProductsController
 
@@ -129,7 +130,12 @@ class ProductsController
         end
       end
     end
-    
+
+    def check_current_orders
+      @orders = @order_line.get_products_from_current_orders.flatten
+      return @orders
+    end
+
     def delete_customer_product
       @product_arr = @product.get_products_by_customer(@active_customer[0])
       puts "Choose an item to delete"
@@ -145,13 +151,26 @@ class ProductsController
       user_input = gets.chomp
       @product_hash.each do |key, val|
         if user_input.to_s == key.to_s
-          puts "Do you want to delete #{val[2]}? (Y/N)"
-          next_user_input = gets.chomp
-          if next_user_input.downcase.to_s == "y"
-            @product.delete_product(@product_hash[key][0])
+          @orders = @order_line.get_products_from_current_orders.flatten
+          if @orders.include?(val[0])
+            puts "Can't delete #{val[2]} because it is in an active order."
+            puts " "
+          else
+            puts "Do you want to delete #{val[2]}? (Y/N)"
+            next_user_input = gets.chomp
+            case next_user_input.downcase.to_s
+            when "y"
+              puts "#{@product_hash[key][2]} has been deleted!"
+              @product.delete_product(@product_hash[key][0])
+            when "n"
+              break
+            end
           end
         end
       end
     end
 
 end
+
+# order = ProductsController.new(1)
+# p order.check_current_orders

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -131,11 +131,6 @@ class ProductsController
       end
     end
 
-    def check_current_orders
-      @orders = @order_line.get_products_from_current_orders.flatten
-      return @orders
-    end
-
     def delete_customer_product
       @product_arr = @product.get_products_by_customer(@active_customer[0])
       puts "Choose an item to delete"

--- a/app/models/order_line.rb
+++ b/app/models/order_line.rb
@@ -31,6 +31,15 @@ class OrderLineModel
     return @order_lines_by_order_id
   end
 
+  # function to retrieve all product_id's from current active orders
+  def get_products_from_current_orders
+    @db.execute("
+    SELECT product_id
+    FROM Order_details
+	  JOIN Orders ON  Order_details.order_id = Orders.order_id
+	  WHERE Orders.pay_method_id IS null")
+  end
+
   # function to retrieve all order lines in the database for a particular product
   def get_order_lines_by_product_id(product_id)
     @order_lines_by_product_id = @db.execute("SELECT * FROM Order_details WHERE product_id = #{product_id}")


### PR DESCRIPTION
#### Descriptions

Updated `.delete_customer_product` method 

Given the user wants to remove a product

When the user has chosen an active customer and chosen `Remove customer product` from the active customer menu

Then the `.delete_customer_product` method list out products associated with that customer

And when one is selected, deletes the product from the database IF the product is not currently in an active order.


#### Steps to Test

Run `ruby app/main.rb` from root folder

Choose an active customer and create a new product. (Thus ensuring that it is not in a current order)

After creating the product. Choose the `Remove customer product` and choose the product that was just created.

Upon choosing the product, it should display "Are you sure you want to delete item? (Y/N)

Upon typing `y`, should delete from database and return to previous menu.

If you choose a product that is currently in an active order, it should tell you it cannot delete the item and return to previous menu.

#### Link to Feature Ticket

https://github.com/c-cannons/bangazon-terminal-interface/issues/7